### PR TITLE
Fix typos, comments, add HTML tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Barlow CTM Website
+
+This repository contains the static HTML for the Barlow CTM website.
+
+## Running Tests
+
+Install the required packages and run `pytest` from the repository root:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
         .container {
             width: 100%;
-            max-width: auto; /* Changed from auto to 100% */
+            max-width: 100%; /* Changed from auto to 100% */
             margin: 0 auto;
             padding: 20px;
         }
@@ -676,7 +676,7 @@
                 <div class="team-member" data-member-id="mackenzie-kassner">
                     <img src="https://files.catbox.moe/bx4u6b.jpg" alt="Mackenzie Kassner" class="profile-picture">
                     <h3 class="member-name">Mackenzie Kassner</h3>
-                    <p class="member-title">Floutist</p>
+                    <p class="member-title">Flautist</p>
                     <p class="member-bio">Delicate and precise flute melodies characterize Mackenzie's playing.</p>
                 </div>
                 <div class="team-member" data-member-id="michael-mininberg">
@@ -907,16 +907,16 @@
     </div>
 
     <div class="modal" id="member-modal">
-         {/* */}
+         <!-- -->
         <button class="modal-close" aria-label="Close member modal">×</button>
         <div class="member-modal-content">
             <div class="member-modal-details" id="member-modal-details">
-                {/* Member details will be populated here by JS */}
+                <!-- Member details will be populated here by JS -->
             </div>
             <div class="member-modal-gallery">
                 <h3>Featured In:</h3>
                 <div class="member-gallery-grid" id="member-modal-gallery-grid">
-                    {/* Associated gallery items will be cloned here by JS */}
+                    <!-- Associated gallery items will be cloned here by JS -->
                 </div>
             </div>
         </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+lxml

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,13 @@
+import pytest
+from lxml import etree
+
+
+def test_html_well_formed():
+    parser = etree.HTMLParser()
+    with open('index.html', 'r', encoding='utf-8') as f:
+        try:
+            etree.parse(f, parser)
+        except etree.XMLSyntaxError as e:
+            pytest.fail(f"HTML syntax error: {e}")
+
+


### PR DESCRIPTION
## Summary
- correct "Flautist" typo in team section
- replace React style comments in member modal with HTML comments
- fix `.container` CSS to use `max-width: 100%`
- add simple HTML validation test
- document how to run the test

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f64a14bfc8329826efc8f5ab7b894