### PR TITLE
Fix mini gallery not showing

### DIFF
--- a/index.html
+++ b/index.html
@@ -907,15 +907,10 @@
     </div>
 
     <div class="modal" id="member-modal">
-<!-- -->
         <button class="modal-close" aria-label="Close member modal">×</button>
         <div class="member-modal-content">
             <div class="member-modal-details" id="member-modal-details">
                 <!-- Member details will be populated here by JS -->
-=======
-        <button class="modal-close" aria-label="Close member modal">×</button>
-        <div class="member-modal-content">
-            <div class="member-modal-details" id="member-modal-details">
             </div>
             <div class="member-modal-gallery">
                 <h3>Featured In:</h3>


### PR DESCRIPTION
## Summary
- remove leftover conflict markers from member modal markup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f68f508c083298d4bfd7347ef6f1e